### PR TITLE
feature: 新增判斷是否有試用資格

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -1,10 +1,6 @@
 const bcrypt = require("bcryptjs");
 const nodemailer = require("nodemailer");
-const {
-  isUndefined,
-  isNotValidString,
-  isNotValidEmail,
-} = require("../utils/validators");
+const { isUndefined, isNotValidString, isNotValidEmail } = require("../utils/validators");
 const generateError = require("../utils/generateError");
 const AppDataSource = require("../db/data-source");
 const { generateJWT, verifyJWT } = require("../utils/jwtUtils");
@@ -17,11 +13,9 @@ const Coach = require("../entities/Coach");
 const Admin = require("../entities/Admin");
 const gmailUserName = config.get("email.gmailUserName");
 const gmailAppPassword = config.get("email.gmailAppPassword");
-const {
-  findRoleAndRepoByEmail,
-  findRepoByRole,
-} = require("../services/roleServices");
+const { findRoleAndRepoByEmail, findRepoByRole } = require("../services/roleServices");
 
+//使用者/教練註冊
 async function postSignup(req, res, next) {
   try {
     const { name, nickname, email, password, password_check } = req.body;
@@ -99,7 +93,7 @@ async function postSignup(req, res, next) {
     next(error);
   }
 }
-
+//管理員註冊
 async function postAdminSignup(req, res, next) {
   try {
     const { email, password, password_check } = req.body;
@@ -159,14 +153,13 @@ async function postAdminSignup(req, res, next) {
       data: {
         id: newAdmin.id,
         email: newAdmin.email,
-
       },
     });
   } catch (error) {
     next(error);
   }
 }
-
+//登入
 async function postLogin(req, res, next) {
   try {
     const { email, password } = req.body;
@@ -211,7 +204,7 @@ async function postLogin(req, res, next) {
     next(error);
   }
 }
-
+//忘記密碼
 async function postForgotPassword(req, res, next) {
   try {
     const { email } = req.body;
@@ -283,7 +276,7 @@ async function postForgotPassword(req, res, next) {
     next(error);
   }
 }
-
+//重設密碼
 async function patchResetPassword(req, res, next) {
   try {
     const { new_password, password_check } = req.body;
@@ -303,10 +296,7 @@ async function patchResetPassword(req, res, next) {
     const passwordPattern = /(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,16}/;
     if (!passwordPattern.test(new_password)) {
       return next(
-        generateError(
-          400,
-          "密碼不符合規則，需要包含英文數字大小寫，最短8個字，最長16個字"
-        )
+        generateError(400, "密碼不符合規則，需要包含英文數字大小寫，最短8個字，最長16個字")
       );
     }
 
@@ -348,10 +338,13 @@ async function patchResetPassword(req, res, next) {
     next(error);
   }
 }
-
-//回傳使用者資訊，方便前端判斷使用者登入狀態，調整右上角顯示狀態
+//驗證登入（回傳使用者資訊）
 async function getMe(req, res, next) {
-  res.json(req.user);
+  res.status(200).json({
+    status: true,
+    message: "成功取得資料",
+    data: req.user,
+  });
 }
 
 module.exports = {

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -11,11 +11,7 @@ const {
   isNotValidUrl,
 } = require("../utils/validators");
 const generateError = require("../utils/generateError");
-const {
-  checkCategoryAccess,
-  hasActiveSubscription,
-  getLatestSubscription,
-} = require("../services/checkServices");
+const { checkCategoryAccess, getLatestSubscription } = require("../services/checkServices");
 const { getTypeByStudentCount } = require("../services/getTypeByStudentCount");
 const formatDate = require("../utils/formatDate"); // 引入日期格式化工具函數
 const bcrypt = require("bcryptjs");
@@ -293,12 +289,12 @@ async function deleteUnlike(req, res, next) {
 async function getCourseType(req, res, next) {
   try {
     const userId = req.user.id;
+    const hasActiveSubscription = req.user.hasActiveSubscription;
     let isEagerness = false;
     let result = [];
 
     //判斷訂閱是否有效
-    const isActive = await hasActiveSubscription(userId);
-    if (!isActive) {
+    if (!hasActiveSubscription) {
       return next(generateError(403, "尚未訂閱或訂閱已失效，無可觀看課程類別"));
     }
 

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -3,85 +3,105 @@ const logger = require("pino")();
 const secret = process.env.JWT_SECRET;
 const generateError = require("../utils/generateError");
 const { verifyJWT } = require("../utils/jwtUtils");
+const { checkHasTrial, checkActiveSubscription } = require("../services/checkServices");
 
 module.exports = async (req, res, next) => {
-	if (!secret || typeof secret !== "string") {
-		logger.error("[Auth] JWT secret 不存在或格式錯誤！");
-	}
-	// 檢查 request header 是否有帶上 authorization 欄位
-	if (
-		!req.headers ||
-		!req.headers.authorization ||
-		!req.headers.authorization.startsWith("Bearer")
-	) {
-		logger.warn("[Auth] Authorization header 遺失或格式錯誤");
-		return next(generateError(401, "請先登入"));
-	}
-	// 解析 header 中的 token
-	const token = req.headers.authorization.split(" ")[1];
-	if (!token) {
-		logger.warn("[Auth] Token 不存在");
-		return next(generateError(401, "請先登入"));
-	}
-	try {
-		//如果token有效，解出payload資訊，並回傳使用者身分（學生/教練/管理員）
-		const payload = await verifyJWT(token, secret);
+  if (!secret || typeof secret !== "string") {
+    logger.error("[Auth] JWT secret 不存在或格式錯誤！");
+  }
+  // 檢查 request header 是否有帶上 authorization 欄位
+  if (
+    !req.headers ||
+    !req.headers.authorization ||
+    !req.headers.authorization.startsWith("Bearer")
+  ) {
+    logger.warn("[Auth] Authorization header 遺失或格式錯誤");
+    return next(generateError(401, "請先登入"));
+  }
+  // 解析 header 中的 token
+  const token = req.headers.authorization.split(" ")[1];
+  if (!token) {
+    logger.warn("[Auth] Token 不存在");
+    return next(generateError(401, "請先登入"));
+  }
+  try {
+    //如果token有效，解出payload資訊，並回傳使用者身分（學生/教練/管理員）
+    const payload = await verifyJWT(token, secret);
+    const userId = payload.id;
+    const role = payload.role;
 
-		//檢查payload資訊中的role對應身分
-		const AppDataSource = require("../db/data-source");
-		const User = require("../entities/User");
-		const Coach = require("../entities/Coach");
-		const Admin = require("../entities/Admin");
+    //檢查payload資訊中的role對應身分
+    const AppDataSource = require("../db/data-source");
+    const User = require("../entities/User");
+    const Coach = require("../entities/Coach");
+    const Admin = require("../entities/Admin");
 
-		let repository;
-		switch (payload.role) {
-			case "USER":
-				repository = AppDataSource.getRepository(User);
-				break;
-			case "COACH":
-				repository = AppDataSource.getRepository(Coach);
-				break;
-			case "ADMIN":
-				repository = AppDataSource.getRepository(Admin);
-				break;
-			default:
-				logger.warn("[Auth] 角色資訊無效");
-				return next(generateError(401, "請先登入"));
-		}
+    let repository;
+    switch (role) {
+      case "USER":
+        repository = AppDataSource.getRepository(User);
+        break;
+      case "COACH":
+        repository = AppDataSource.getRepository(Coach);
+        break;
+      case "ADMIN":
+        repository = AppDataSource.getRepository(Admin);
+        break;
+      default:
+        logger.warn("[Auth] 角色資訊無效");
+        return next(generateError(401, "請先登入"));
+    }
 
-		// 根據token解出的id，去資料庫找對應的user（學生/教練/管理員）
-		const user = await repository.findOneBy({ id: payload.id });
-		if (!user) {
-			logger.warn(`[Auth] 找不到使用者 ID: ${payload.id}`);
-			return next(generateError(401, "請先登入"));
-		}
+    // 根據token解出的id，去資料庫找對應的user（學生/教練/管理員）
+    const user = await repository.findOneBy({ id: userId });
+    if (!user) {
+      logger.warn(`[Auth] 找不到使用者 ID: ${userId}`);
+      return next(generateError(401, "請先登入"));
+    }
 
-		// 根據角色設定displayName
-		let displayName;
-		switch (payload.role) {
-			case "USER":
-				displayName = user.name;
-				break;
-			case "COACH":
-				displayName = user.nickname;
-				break;
-			case "ADMIN":
-				displayName = user.email.split("@")[0];
-				break;
-			default:
-				logger.warn("[Auth] 角色資訊無效");
-				return next(generateError(401, "請先登入"));
-		}
-		//回傳使用者資訊
-		req.user = {
-			id: payload.id,
-			role: payload.role,
-			name: displayName,
-			profile_image_url: user.profile_image_url || null,
-		};
-		next();
-	} catch (error) {
-		logger.error(`[Auth] ${req.method} ${req.url}`, error);
-		next(error);
-	}
+    // 根據角色設定displayName
+    let displayName;
+    switch (role) {
+      case "USER":
+        displayName = user.name;
+        break;
+      case "COACH":
+        displayName = user.nickname;
+        break;
+      case "ADMIN":
+        displayName = user.email.split("@")[0];
+        break;
+      default:
+        logger.warn("[Auth] 角色資訊無效");
+        return next(generateError(401, "請先登入"));
+    }
+
+    //判斷此人是否有試用資格
+    const hasTrial = await checkHasTrial(userId);
+
+    //判斷此人最新一筆訂閱是否仍有效
+    const hasActiveSubscription = await checkActiveSubscription(userId);
+
+    //設定要回傳的使用者資料內容
+    if (role !== "USER") {
+      req.user = {
+        id: userId, //id
+        role: role, //角色
+        name: displayName, //顯示名稱
+      };
+    } else {
+      req.user = {
+        id: userId, //id
+        role: role, //角色
+        displayName: displayName, //顯示名稱
+        profile_image_url: user.profile_image_url || null, //大頭貼url
+        hasTrial: hasTrial, //是否有試用資格
+        hasActiveSubscription: hasActiveSubscription, //最新訂閱是否有效
+      };
+    }
+    next();
+  } catch (error) {
+    logger.error(`[Auth] ${req.method} ${req.url}`, error);
+    next(error);
+  }
 };

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -78,16 +78,14 @@ module.exports = async (req, res, next) => {
 
     //判斷此人是否有試用資格
     const hasTrial = await checkHasTrial(userId);
-
     //判斷此人最新一筆訂閱是否仍有效
     const hasActiveSubscription = await checkActiveSubscription(userId);
-
     //設定要回傳的使用者資料內容
     if (role !== "USER") {
       req.user = {
         id: userId, //id
         role: role, //角色
-        name: displayName, //顯示名稱
+        displayName: displayName, //顯示名稱
       };
     } else {
       req.user = {

--- a/services/checkServices.js
+++ b/services/checkServices.js
@@ -1,5 +1,6 @@
 const AppDataSource = require("../db/data-source");
 const userRepo = AppDataSource.getRepository("User");
+const planRepo = AppDataSource.getRepository("Plan");
 const courseRepo = AppDataSource.getRepository("Course");
 const subscriptionRepo = AppDataSource.getRepository("Subscription");
 const subscriptionSkillRepo = AppDataSource.getRepository("Subscription_Skill");
@@ -15,7 +16,7 @@ const getLatestSubscription = async (userId) => {
 };
 
 //判斷訂閱是否有效
-const hasActiveSubscription = async (userId) => {
+const checkActiveSubscription = async (userId) => {
   //取得此人最新的訂閱紀錄
   const latestSubscription = await getLatestSubscription(userId);
   // 沒有訂閱紀錄就直接回傳 false
@@ -50,8 +51,20 @@ const checkCategoryAccess = async (userId, courseId) => {
   return !!result; //若查有此資料，回傳true,否則回傳false
 };
 
+//判斷此人是否有試用資格
+const checkHasTrial = async (userId) => {
+  const plan = await planRepo.findOneBy({ name: "Eagerness方案-7天試用" });
+  const trialPlan_id = plan.id;
+  //從此人的訂閱紀錄中查找是否有方案名為"Eagerness方案-7天試用"
+  const result = await subscriptionRepo.findOneBy({ user_id: userId, plan_id: trialPlan_id });
+  //有試用紀錄回傳false（已無試用資格）
+  //沒使用記錄回傳true （尚有試用資格）
+  return !result;
+};
+
 module.exports = {
   checkCategoryAccess,
-  hasActiveSubscription,
+  checkActiveSubscription,
   getLatestSubscription,
+  checkHasTrial,
 };


### PR DESCRIPTION
1.auth/me API回傳資訊新增：hasTrial, hasActiveSubscription ，幫助前端判斷是否有試用資格、訂閱是否有效

2.在 auth.js middleware 中，若引入的 service 函式與變數命名相同（例如 hasActiveSubscription），會出錯。
錯誤訊息 "message": "Cannot access 'hasActiveSubscription' before initialization"

所以 checkServices.js 中函式命名我統一改為 checkHasTrial, checkActiveSubscription，middleware 中接收結果的變數改為 hasTrial, hasActiveSubscription，避免同名錯誤

3.因為auth/me的功能邏輯寫在auth middleware裡，所以之後只要api有先用到auth，可以直接呼叫以下變數，不用另外去查或呼叫service，減少重複查詢。

const userID/coachId/adminId = req.user.id
const role = req.user.role //角色
const displayName = req.user.displayName //右上角顯示的名稱
const profile_image_url = req.user.profile_image_url //大頭貼網址
const hasTrial = req.user.hasTrial //是否有試用資格
const hasActiveSubscription = req.user.hasActiveSubscription //訂閱是否有效