### PR TITLE
fix：取得課程列表篩選參數修正

### DIFF
--- a/controllers/course.js
+++ b/controllers/course.js
@@ -197,7 +197,7 @@ async function getCourses(req, res, next) {
       if (!skill) {
         return next(generateError(404, "查無此課程類別"));
       }
-      filteredCourses = await courseFilter(rawCourses, skillId);
+      filteredCourses = await courseFilter(rawCourses, null, skillId);
     }
     //分頁設定
     const rawPage = req.query.page; //當前頁數


### PR DESCRIPTION
1.第二個參數需回傳null，否則輸入skillId，篩選類別會失效
因為跟取得可觀看課程列表共用service，category的參數還是要回傳，不然會直接回傳未篩選的課程
