### PR TITLE
feature : 綠界金流串接

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,9 @@ app.set("view engine", "ejs");
 
 app.use(logger("dev"));
 app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
+// 處理來自 HTML form 的 application/x-www-form-urlencoded 資料格式
+// 設定 extended: true 可支援巢狀物件（例如 user[name]=Jenni）
+app.use(express.urlencoded({ extended: true }));
 app.use(cors());
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, "public")));

--- a/config/ecpay.js
+++ b/config/ecpay.js
@@ -1,0 +1,7 @@
+module.exports = {
+  merchantId: process.env.MERCHANT_ID, //特店編號
+  hashKey: process.env.HASH_KEY, //串接金鑰HashKey
+  hashIv: process.env.HASH_IV, //串接金鑰HashIV
+  returnUrl: process.env.RETURN_URL, //付款完成導回該網址
+  notifyUrl: process.env.NOTIFY_URL, //付款狀態通知網址
+};

--- a/config/index.js
+++ b/config/index.js
@@ -9,6 +9,7 @@ const web = require("./web");
 const secret = require("./secret");
 const email = require("./email"); // 新增 email 設定
 const mux = require("./mux");
+const ecpay = require("./ecpay");
 
 // 整合所有設定檔案
 const config = {
@@ -17,6 +18,7 @@ const config = {
   secret,
   email, // 添加 email 設定
   mux, //添加mux串流token
+  ecpay, //綠界金流
 };
 
 class ConfigManager {

--- a/controllers/course.js
+++ b/controllers/course.js
@@ -3,7 +3,6 @@ const skillRepo = AppDataSource.getRepository("Skill");
 const coachRepo = AppDataSource.getRepository("Coach");
 const coachSkillRepo = AppDataSource.getRepository("Coach_Skill");
 const courseRepo = AppDataSource.getRepository("Course");
-const courseChapterRepo = AppDataSource.getRepository("Course_Chapter");
 
 //services
 const { getAllCourseTypes } = require("../services/typeServices");

--- a/controllers/payment.js
+++ b/controllers/payment.js
@@ -1,0 +1,179 @@
+const dayjs = require("dayjs");
+const config = require("../config/index");
+const { merchantId, returnUrl, notifyUrl } = config.get("ecpay"); //引入綠界金流參數
+const { generateCMV } = require("../services/ecPayServices");
+const generateError = require("../utils/generateError");
+const AppDataSource = require("../db/data-source");
+const subscriptionRepo = AppDataSource.getRepository("Subscription");
+const uuid16 = require("uuid").v4().replace(/-/g, "").slice(0, 16); //取uuid前16位並移除dash
+
+//新增付款
+async function postCreatePayment(req, res, next) {
+  try {
+    const { price, order_number, plan_name } = req.body; //前端需回傳price，order_number，plan_name
+    if (!order_number) return next(generateError(400, "缺少訂單編號"));
+    const subscription = await subscriptionRepo.findOneBy({ order_number: order_number });
+    if (!subscription) return next(generateError(404, "查無訂單"));
+    if (subscription.is_paid) return next(generateError(400, "此訂單已付款"));
+
+    // 設定金流特店訂單編號，非訂閱紀錄的訂單編號
+    // 如ORD9c6ca7aa19bd401d，綠界要求特店訂單編號不可重複，英數字大小寫混合
+    const merchantTradeNo = `ORD${uuid16}`;
+    // 將 merchantTradeNo 寫入當前訂閱紀錄
+    subscription.merchant_trade_no = merchantTradeNo;
+    await subscriptionRepo.save(subscription);
+    //設定要回傳的資料
+    const postdata = {
+      MerchantID: merchantId, //特店編號
+      MerchantTradeNo: merchantTradeNo, //特店訂單編號均為唯一值，不可重複使用。英數字大小寫混合
+      MerchantTradeDate: dayjs().format("YYYY/MM/DD HH:mm:ss"), //格式為：yyyy/MM/dd HH:mm:ss
+      PaymentType: "aio", //交易類型，固定回傳aio
+      TotalAmount: price, //交易金額
+      TradeDesc: "sportify會員訂閱", //交易描述
+      ItemName: plan_name, //商品名稱
+      ChoosePayment: "Credit", //選擇預設付款方式，信用卡
+      EncryptType: 1, //CheckMacValue加密類型，固定回傳1，代表SHA256
+      PeriodAmount: price, //每次授權金額
+      PeriodType: "M", //週期種類，月週期
+      Frequency: 1, //執行頻率，最多1-12次
+      ExecTimes: 12, //執行次數，範圍為2-99次
+      BindingCard: 1, //是否綁定信用卡，1=是
+      MerchantMemberID: `${merchantId}+sportify123`,
+      ReturnURL: notifyUrl, //第一次定期定額授權成功，扣款資訊回傳網址
+      PeriodReturnURL: notifyUrl, //第二次開始的定期定額扣款資訊回傳網址
+      ClientBackURL: returnUrl, //付款完成導回此網址
+    };
+    //在物件內新增CheckMacValue檢查碼欄位
+    postdata.CheckMacValue = generateCMV(postdata);
+    //整理成html form回傳格式
+    const formInputs = Object.entries(postdata)
+      .map(([key, value]) => `<input type="hidden" name="${key}" value="${value}" />`)
+      .join("\n");
+    //回傳html form
+    const form = `
+    <form id="ecpay-form" method="post" action="https://payment-stage.ecpay.com.tw/Cashier/AioCheckOut/V5">
+    ${formInputs}
+    </form>
+    <script>document.getElementById('ecpay-form').submit();</script>
+    `;
+    res.send(form);
+  } catch (error) {
+    next(error);
+  }
+}
+//取消定期扣款
+async function postCancelPayment(req, res, next) {
+  try {
+    const { merchant_trade_no } = req.body; //前端需回傳merchant_trade_no
+    if (!merchant_trade_no) return next(generateError(400, "缺少綠界金流特店訂單編號"));
+    const subscription = await subscriptionRepo.findOneBy({ merchant_trade_no: merchant_trade_no });
+    if (!subscription) return next(generateError(404, "查無訂單"));
+
+    const postdata = {
+      MerchantID: merchantId,
+      MerchantTradeNo: merchant_trade_no,
+      Action: "Cancel",
+      TimeStamp: dayjs().unix(), // 確保每次發送時為最新時間
+    };
+    //在物件內新增CheckMacValue檢查碼欄位
+    postdata.CheckMacValue = generateCMV(postdata);
+    //整理成html form回傳格式
+    const formInputs = Object.entries(postdata)
+      .map(([key, value]) => `<input type="hidden" name="${key}" value="${value}" />`)
+      .join("\n");
+    const form = `
+  <form id="cancel-form" method="post" action="https://payment-stage.ecpay.com.tw/Cashier/CreditCardPeriodAction">
+  ${formInputs}
+  </form>
+  <script>document.getElementById('cancel-form').submit();</script>
+  `;
+    res.send(form);
+  } catch (error) {
+    next(error);
+  }
+}
+//webhook通知付款結果
+async function postPaymentConfirm(req, res, next) {
+  try {
+    const { CheckMacValue, ...data } = req.body; //把CMV欄位單獨取出
+    //驗證 CheckMacValue 是否正確
+    const localCMV = generateCMV(data);
+    if (localCMV !== CheckMacValue) {
+      return next(
+        generateError(400, "通知驗證失敗：CheckMacValue 驗證不符，資料可能被修改或參數異常")
+      );
+    }
+    //查找對應訂單紀錄
+    const merchant_trade_no = data.MerchantTradeNo; //取得綠界金流特店訂單編號
+    const subscription = await subscriptionRepo.findOneBy({
+      merchant_trade_no: merchant_trade_no,
+    });
+    if (!subscription) return next(generateError(404, "查無訂單"));
+    if (subscription.is_paid) {
+      //此訂單已處理過 webhook，不重複處理，叫綠界不要再回傳
+      return res.send("1|OK");
+    }
+    if (Number(data.TradeAmt) !== subscription.price) {
+      return next(generateError(400, "訂單金額與實際付款金額不一致，請聯絡綠界金流客服確認"));
+    }
+    //若付款成功
+    if (data.RtnCode === "1") {
+      const paymentDate = dayjs(data.PaymentDate, "YYYY/MM/DD HH:mm:ss");
+      //更新訂單紀錄
+      if (data.PaymentType === "Credit_CreditCard") {
+        subscription.payment_method = "信用卡"; //付款方式
+      } else {
+        subscription.payment_method = data.PaymentType; //付款方式
+      }
+      subscription.purchased_at = paymentDate.toDate(); //付款時間
+      subscription.start_at = paymentDate.toDate(); //訂閱開始時間
+      // 訂閱結束時間為下一個月的同一天（若無該天自動退到月底）
+      subscription.end_at = paymentDate.add(1, "month").toDate(); //訂閱結束時間
+      subscription.is_paid = true; //付款狀態，紀錄為已付款
+      subscription.invoice_image_url = null; //TODO:發票功能待確認
+      subscription.is_renewal = true; //預設自動續訂
+      await subscriptionRepo.save(subscription); //更新資料庫
+      return res.send("1|OK"); //綠界要求回傳此格式，表示成功接收
+    } else {
+      return next(generateError(400, `付款失敗：${data.RtnMsg}`)); //RtnMsg綠界回傳錯誤訊息
+    }
+  } catch (error) {
+    next(error);
+  }
+}
+// 接收取消結果的通知（從前端導回通知並再次檢查）
+async function postCancelConfirm(req, res, next) {
+  try {
+    const { CheckMacValue, ...data } = req.body; //把CMV欄位單獨取出
+    //驗證 CheckMacValue 是否正確
+    const localCMV = generateCMV(data);
+    if (localCMV !== CheckMacValue) {
+      return next(
+        generateError(400, "通知驗證失敗：CheckMacValue 驗證不符，資料可能被修改或參數異常")
+      );
+    }
+    //查找對應訂單紀錄
+    const merchant_trade_no = data.MerchantTradeNo; //取得綠界金流特店訂單編號
+    const subscription = await subscriptionRepo.findOneBy({
+      merchant_trade_no: merchant_trade_no,
+    });
+    if (!subscription) return next(generateError(404, "查無訂單"));
+
+    //若是取消定期定額扣款狀態通知
+    if (data.RtnCode === "1") {
+      subscription.is_renewal = false; //取消自動續訂
+      await subscriptionRepo.save(subscription); //更新資料庫
+    } else {
+      return next(generateError(400, `取消定期定額扣款失敗：${data.RtnMsg}`)); //RtnMsg綠界回傳錯誤訊息
+    }
+  } catch (error) {
+    next(error);
+  }
+}
+
+module.exports = {
+  postCreatePayment,
+  postCancelPayment,
+  postPaymentConfirm,
+  postCancelConfirm,
+};

--- a/controllers/payment.js
+++ b/controllers/payment.js
@@ -5,7 +5,6 @@ const { generateCMV } = require("../services/ecPayServices");
 const generateError = require("../utils/generateError");
 const AppDataSource = require("../db/data-source");
 const subscriptionRepo = AppDataSource.getRepository("Subscription");
-const uuid16 = require("uuid").v4().replace(/-/g, "").slice(0, 16); //取uuid前16位並移除dash
 
 //新增付款
 async function postCreatePayment(req, res, next) {
@@ -18,6 +17,7 @@ async function postCreatePayment(req, res, next) {
 
     // 設定金流特店訂單編號，非訂閱紀錄的訂單編號
     // 如ORD9c6ca7aa19bd401d，綠界要求特店訂單編號不可重複，英數字大小寫混合
+    const uuid16 = require("uuid").v4().replace(/-/g, "").slice(0, 16); //取uuid前16位並移除dash
     const merchantTradeNo = `ORD${uuid16}`;
     // 將 merchantTradeNo 寫入當前訂閱紀錄
     subscription.merchant_trade_no = merchantTradeNo;

--- a/entities/Subscription.js
+++ b/entities/Subscription.js
@@ -24,27 +24,57 @@ module.exports = new EntitySchema({
       type: "uuid",
       nullable: false,
     },
-    // 訂閱購買時間
-    purchased_at: {
-      type: "timestamp",
-      nullable: false,
-    },
-    // 訂單編號（外部金流系統回傳的 ID）
+    // 訂單編號
     order_number: {
       type: "varchar",
       length: 20,
       nullable: false,
     },
+    // 價格（台幣金額）
+    price: {
+      type: "int",
+      nullable: false,
+    },
+    // 付款狀態(未付款/已付款)
+    is_paid: {
+      type: "boolean",
+      nullable: false,
+      default: false,
+    },
+    // 建立訂單時間
+    created_at: {
+      type: "timestamp",
+      createDate: true,
+    },
+    // 更新訂單時間
+    updated_at: {
+      type: "timestamp",
+      updateDate: true,
+    },
+
+    // 付款後才會新增以下欄位
+
+    // 綠界金流特店訂單編號
+    merchant_trade_no: {
+      type: "varchar",
+      length: 20,
+      nullable: true,
+    },
+    // 付款時間
+    purchased_at: {
+      type: "timestamp",
+      nullable: true,
+    },
     // 訂閱開始與結束時間
     start_at: {
       type: "timestamp",
-      nullable: false,
+      nullable: true,
     },
     end_at: {
       type: "timestamp",
-      nullable: false,
+      nullable: true,
     },
-    // 付款方式（例如信用卡、Apple Pay）
+    // 付款方式（如信用卡）
     payment_method: {
       type: "varchar",
       length: 20,
@@ -56,16 +86,11 @@ module.exports = new EntitySchema({
       length: 2048,
       nullable: true,
     },
-    // 價格（台幣金額）
-    price: {
-      type: "int",
-      nullable: false,
-    },
-    // 付款狀態   
-    is_paid: {
+    // 是否自動續訂方案
+    is_renewal: {
       type: "boolean",
       nullable: false,
-      default: false,
+      default: false, // 預設為尚未訂閱
     },
   },
 

--- a/entities/User.js
+++ b/entities/User.js
@@ -49,13 +49,6 @@ module.exports = new EntitySchema({
       nullable: true,
     },
 
-    // 是否自動續訂方案
-    is_renewal: {
-      type: "boolean",
-      nullable: false,
-      default: false, // 預設為尚未訂閱
-    },
-
     // 頭像圖片網址
     profile_image_url: {
       type: "varchar",

--- a/routes/user.js
+++ b/routes/user.js
@@ -5,6 +5,7 @@ const isUser = require("../middlewares/isUser");
 const isSelf = require("../middlewares/isSelf");
 const userController = require("../controllers/user");
 const ratingController = require("../controllers/rating");
+const paymentController = require("../controllers/payment");
 
 //固定路由
 //固定路由順序要放在動態路由前，如:userId，否則會被/:userId的路由攔截
@@ -23,6 +24,14 @@ router.get("/subscriptions", auth, isUser, userController.getSubscriptions);
 router.post("/subscription", auth, isUser, userController.postSubscription);
 //取消訂閱方案
 router.patch("/subscription", auth, isUser, userController.patchSubscription);
+//新增付款
+router.post("/create-payment", auth, isUser, paymentController.postCreatePayment);
+//webhook回傳付款結果
+router.post("/payment-confirm", paymentController.postPaymentConfirm);
+//取消定期扣款
+router.post("/cancel-payment", auth, isUser, paymentController.postCancelPayment);
+// 接收取消結果的通知（從前端導回）
+router.post("/cancel-confirm", paymentController.postCancelConfirm);
 
 //動態路由
 

--- a/services/checkServices.js
+++ b/services/checkServices.js
@@ -19,8 +19,8 @@ const getLatestSubscription = async (userId) => {
 const checkActiveSubscription = async (userId) => {
   //取得此人最新的訂閱紀錄
   const latestSubscription = await getLatestSubscription(userId);
-  // 沒有訂閱紀錄就直接回傳 false
-  if (!latestSubscription) return false;
+  if (!latestSubscription) return false; //查無訂閱紀錄
+  if (!latestSubscription.is_paid) return false; //尚未付款
 
   const now = new Date();
   const validDate = new Date(latestSubscription.end_at);

--- a/services/ecPayServices.js
+++ b/services/ecPayServices.js
@@ -1,0 +1,43 @@
+const crypto = require("crypto");
+const config = require("../config/index");
+const { hashKey, hashIv } = config.get("ecpay");
+
+// 產生綠界要求的CheckMacValue
+function generateCMV(params) {
+  // 排序參數（ASCII 升冪）
+  const sorted = {};
+  Object.keys(params)
+    .sort()
+    .forEach((key) => {
+      sorted[key] = String(params[key]); // 確保參數值轉成字串
+    });
+
+  // 串接格式
+  let raw = `HashKey=${hashKey}&`;
+  raw += Object.entries(sorted)
+    .map(([key, val]) => `${key}=${val}`)
+    .join("&");
+  raw += `&HashIV=${hashIv}`;
+
+  // 按照綠界要求的規則編碼
+  function encodeEcpayRaw(raw) {
+    return encodeURIComponent(raw)
+      .toLowerCase()
+      .replace(/%20/g, "+") // 空白轉+號
+      .replace(/%21/g, "!") // 驚嘆號不編碼
+      .replace(/%28/g, "(") // 左括號不編碼
+      .replace(/%29/g, ")") // 右括號不編碼
+      .replace(/%2a/g, "*") // 星號不編碼
+      .replace(/%2d/g, "-") // 減號不編碼
+      .replace(/%2e/g, ".") // 點號不編碼
+      .replace(/%5f/g, "_"); // 底線不編碼
+  }
+  raw = encodeEcpayRaw(raw);
+  //SHA256加密 + 轉大寫
+  const hash = crypto.createHash("sha256").update(raw).digest("hex").toUpperCase();
+  return hash;
+}
+
+module.exports = {
+  generateCMV,
+};


### PR DESCRIPTION
新增付款、驗證付款、取消付款、驗證取消付款4隻API

1. app.js中app.use(express.urlencoded({ extended: false }));改為true,支援x-www-form-urlencoded 資料格式回傳

2. subscription資料表調整，新增 merchant_trade_no、創建訂單時間、更新訂單時間欄位

3. 把user資料表的「是否續訂is_renewal」移到subsctiption資料表

「是否續訂」屬於某一筆「訂閱」的屬性，非「使用者」屬性，每筆訂閱的續訂狀態可能不同。
「是否續訂」是根據webhook回傳的付款結果來決定，預設為否，付款成功改為是，取消訂閱成功改為否。
而每一次webhook結果都是對應單筆訂閱紀錄，而非直接對應使用者。
如果is_renewal欄位只對應單一使用者，不對應單筆訂閱紀錄的話，可能會被錯誤改寫，如以下情境：
 
舊方案正在取消中（延遲），但新方案已建立成功，is_renewal變成true之後，舊方案才取消成功，is_renewal 又變成 false
 
如果「是否續訂」欄位直接對應訂閱紀錄，就能避免以上狀況發生。

4.付款後才會有購買時間跟生效的訂閱期間，所以相關欄位移到付款API內新增，新增訂閱API會自動新增訂單創建跟更新的時間。

5.大致流程：
新增訂閱API → 金流端付款API → webhook API  → 更新訂閱狀態
金流端取消訂閱API→前端取得綠界前端回傳資訊→驗證取消API→更新續訂狀態

6.有新增一些TODO的註解，關於訂閱相關API可能需要改動的部分

7.取消訂閱，綠界不會發送webhook，只會在前端顯示相關狀態字串，如圖![image](https://github.com/user-attachments/assets/a87b169b-ecc1-46fb-b34f-3c8a98316de3)
需要前端按照格式回傳相關物件，並打驗證取消付款的API來檢查是否真的取消成功。

8.付款/取消付款API都需要用瀏覽器回傳html表單，才會跳到金流頁面，若要用postman測試，可以直接將回傳結果複製並新增在一個html檔案內，並用瀏覽器打開，就可以跳到金流頁面。

9.webhook的API本地可以用ngrok測試

10.綠界金流env
特店編號MerchantID：3002607
串接金鑰HashKey：pwFHCqoQZGmho4w6
串接金鑰HashIV：EkRm7iFT261dpevs

11.測試信用卡：
4311-9511-1111-1111
安全碼 : 任意輸入三碼數字

若想登入綠界後台使用進階功能，請參考以下連結：
https://developers.ecpay.com.tw/?p=2856&gad_source=1&gad_campaignid=21331775467&gbraid=0AAAAADLSIOUN65cAGVJdk0ADx6tXNOpsQ&gclid=Cj0KCQjwucDBBhDxARIsANqFdr1z2GAaPb7dOWoM2_Hj9HHoKptxNUJtzsYz7cPWmGCPRaYWKdWoLXIaAjytEALw_wcB