### PR TITLE
fix：補充非首次定期定額扣款邏輯

### DIFF
--- a/controllers/payment.js
+++ b/controllers/payment.js
@@ -1,8 +1,10 @@
 const dayjs = require("dayjs");
+const logger = require("pino")();
 const config = require("../config/index");
 const { merchantId, returnUrl, notifyUrl } = config.get("ecpay"); //引入綠界金流參數
 const { generateCMV } = require("../services/ecPayServices");
 const generateError = require("../utils/generateError");
+const generateOrderNumber = require("../utils/generateOrderNumber"); // 引入生成訂單編號的工具函數
 const AppDataSource = require("../db/data-source");
 const subscriptionRepo = AppDataSource.getRepository("Subscription");
 
@@ -14,6 +16,8 @@ async function postCreatePayment(req, res, next) {
     const subscription = await subscriptionRepo.findOneBy({ order_number: order_number });
     if (!subscription) return next(generateError(404, "查無訂單"));
     if (subscription.is_paid) return next(generateError(400, "此訂單已付款"));
+    if (!price) return next(generateError(400, "缺少訂單金額"));
+    if (!plan_name) return next(generateError(400, "缺少訂閱方案名稱"));
 
     // 設定金流特店訂單編號，非訂閱紀錄的訂單編號
     // 如ORD9c6ca7aa19bd401d，綠界要求特店訂單編號不可重複，英數字大小寫混合
@@ -61,6 +65,7 @@ async function postCreatePayment(req, res, next) {
     next(error);
   }
 }
+
 //取消定期扣款
 async function postCancelPayment(req, res, next) {
   try {
@@ -92,6 +97,7 @@ async function postCancelPayment(req, res, next) {
     next(error);
   }
 }
+
 //webhook通知付款結果
 async function postPaymentConfirm(req, res, next) {
   try {
@@ -103,44 +109,108 @@ async function postPaymentConfirm(req, res, next) {
         generateError(400, "通知驗證失敗：CheckMacValue 驗證不符，資料可能被修改或參數異常")
       );
     }
-    //查找對應訂單紀錄
+    //若付款失敗，data.RtnCode !== "1"
+    if (data.RtnCode !== "1") return next(generateError(400, `付款失敗：${data.RtnMsg}`)); //RtnMsg綠界回傳錯誤訊息
     const merchant_trade_no = data.MerchantTradeNo; //取得綠界金流特店訂單編號
-    const subscription = await subscriptionRepo.findOneBy({
-      merchant_trade_no: merchant_trade_no,
+    //查找此筆定期定額扣款最新訂單紀錄
+    const latestSub = await subscriptionRepo.findOne({
+      where: {
+        merchant_trade_no: merchant_trade_no,
+      },
+      order: {
+        purchased_at: "DESC",
+      },
     });
-    if (!subscription) return next(generateError(404, "查無訂單"));
-    if (subscription.is_paid) {
-      //此訂單已處理過 webhook，不重複處理，叫綠界不要再回傳
-      return res.send("1|OK");
-    }
-    if (Number(data.TradeAmt) !== subscription.price) {
+    if (!latestSub) return next(generateError(404, "查無相關定期定額訂單"));
+    if (Number(data.TradeAmt) !== latestSub.price) {
+      logger.warn(`[Webhook] 訂單金額不一致：實付 ${data.TradeAmt} ≠ 訂單 ${latestSub.price}`);
       return next(generateError(400, "訂單金額與實際付款金額不一致，請聯絡綠界金流客服確認"));
     }
-    //若付款成功
-    if (data.RtnCode === "1") {
-      const paymentDate = dayjs(data.PaymentDate, "YYYY/MM/DD HH:mm:ss");
-      //更新訂單紀錄
-      if (data.PaymentType === "Credit_CreditCard") {
-        subscription.payment_method = "信用卡"; //付款方式
-      } else {
-        subscription.payment_method = data.PaymentType; //付款方式
-      }
-      subscription.purchased_at = paymentDate.toDate(); //付款時間
-      subscription.start_at = paymentDate.toDate(); //訂閱開始時間
+    //取得付款日期
+    const paymentDate = dayjs(data.PaymentDate, "YYYY/MM/DD HH:mm:ss");
+
+    //若為第一次定期定額扣款，更新訂單紀錄
+    if (data.TotalSuccessTimes === 1) {
+      latestSub.payment_method =
+        data.PaymentType === "Credit_CreditCard" ? "信用卡" : data.PaymentType; //付款方式
+      latestSub.purchased_at = paymentDate.toDate(); //付款時間
+      latestSub.start_at = paymentDate.toDate(); //訂閱開始時間
       // 訂閱結束時間為下一個月的同一天（若無該天自動退到月底）
-      subscription.end_at = paymentDate.add(1, "month").toDate(); //訂閱結束時間
-      subscription.is_paid = true; //付款狀態，紀錄為已付款
-      subscription.invoice_image_url = null; //TODO:發票功能待確認
-      subscription.is_renewal = true; //預設自動續訂
-      await subscriptionRepo.save(subscription); //更新資料庫
-      return res.send("1|OK"); //綠界要求回傳此格式，表示成功接收
+      latestSub.end_at = paymentDate.add(1, "month").toDate(); //訂閱結束時間
+      latestSub.is_paid = true; //付款狀態，紀錄為已付款
+      latestSub.invoice_image_url = null; //TODO:發票功能待確認
+      latestSub.is_renewal = true; //預設自動續訂
+      const newSub = await subscriptionRepo.save(latestSub); //更新資料庫
+      if (!newSub) {
+        return next(generateError(500, "更新資料失敗"));
+      }
     } else {
-      return next(generateError(400, `付款失敗：${data.RtnMsg}`)); //RtnMsg綠界回傳錯誤訊息
+      //若非第一次定期定額扣款，創建新的訂單紀錄
+      //確認webhook沒有重複打入，避免重複創建新訂閱紀錄
+      const exist = await subscriptionRepo.findOne({
+        where: {
+          merchant_trade_no: latestSub.merchant_trade_no,
+          purchased_at: paymentDate.toDate(),
+        },
+      });
+      if (exist) return res.send("1|OK");
+      if (!latestSub.is_renewal) {
+        logger.warn(`[Webhook] 收到非續訂狀態的扣款：訂單 ${latestSub.order_number}`);
+      }
+      //撈出資料庫今日最新訂單，並創建
+      const todayStr = paymentDate.format("YYYYMMDD");
+      const todayMaxOrder = await subscriptionRepo.findOne({
+        where: { order_number: Like(`${todayStr}%`) }, // 前 8 碼為今天日期
+        order: { order_number: "DESC" }, // 照字串遞減排序（越大的越前面）
+        take: 1, // 只取最新的一筆
+      });
+      const startingOrderNumber = todayMaxOrder?.order_number || todayStr + "0000";
+      const orderNumber = generateOrderNumber(startingOrderNumber);
+      //創建新訂單前，先停用舊訂單的續訂
+      await subscriptionRepo.update(
+        {
+          user_id: latestSub.user_id,
+          is_renewal: true,
+        },
+        {
+          is_renewal: false, // 停用未關閉的續訂
+        }
+      );
+      //創建新訂單前，先停止未到期的訂單有效期（預防兩個有效訂閱同時存在）
+      await subscriptionRepo.update(
+        {
+          user_id: latestSub.user_id,
+          end_at: MoreThan(paymentDate.toDate()), // 停用未到期的訂單
+        },
+        {
+          end_at: paymentDate.toDate(), // 停用未關閉的續訂
+        }
+      );
+      const newSub = subscriptionRepo.create({
+        user_id: latestSub.user_id,
+        plan_id: latestSub.plan_id,
+        order_number: orderNumber,
+        price: data.TradeAmt, //訂單金額
+        is_paid: true, //付款狀態，紀錄為已付款
+        merchant_trade_no: merchant_trade_no, //定期定額扣款都是用同一組綠界編號
+        purchased_at: paymentDate.toDate(), //付款時間
+        start_at: paymentDate.toDate(), //訂閱開始時間
+        end_at: paymentDate.add(1, "month").toDate(), //訂閱結束時間
+        payment_method: data.PaymentType === "Credit_CreditCard" ? "信用卡" : data.PaymentType, //付款方式
+        invoice_image_url: null, //TODO:發票功能待確認
+        is_renewal: true, //預設自動續訂
+      });
+      const savedSub = await subscriptionRepo.save(newSub);
+      if (!savedSub) {
+        return next(generateError(500, "資料儲存失敗"));
+      }
     }
+    return res.send("1|OK"); //綠界要求回傳此格式，表示成功接收
   } catch (error) {
     next(error);
   }
 }
+
 //接收取消結果的通知（從前端導回通知並再次檢查）
 async function postCancelConfirm(req, res, next) {
   try {
@@ -148,9 +218,7 @@ async function postCancelConfirm(req, res, next) {
     //驗證 CheckMacValue 是否正確
     const localCMV = generateCMV(data);
     if (localCMV !== CheckMacValue) {
-      return next(
-        generateError(400, "通知驗證失敗：CheckMacValue 驗證不符，資料可能被修改或參數異常")
-      );
+      return next(generateError(400, "驗證失敗：CheckMacValue 驗證不符，資料可能被修改或參數異常"));
     }
     //查找對應訂單紀錄
     const merchant_trade_no = data.MerchantTradeNo; //取得綠界金流特店訂單編號

--- a/entities/Coach.js
+++ b/entities/Coach.js
@@ -74,6 +74,11 @@ module.exports = new EntitySchema({
     },
 
     //以下為驗證教練身分需要資料
+    is_verified: {
+      type: "boolean",
+      default: false, // 是否已驗證教練身分，預設為 false
+      nullable: true,
+    },
     realname: {
       type: "varchar",
       length: 50,

--- a/entities/Subscription.js
+++ b/entities/Subscription.js
@@ -29,6 +29,7 @@ module.exports = new EntitySchema({
       type: "varchar",
       length: 20,
       nullable: false,
+      unique: true, // 確保訂單編號唯一
     },
     // 價格（台幣金額）
     price: {


### PR DESCRIPTION
1.第一次授權，先打創建訂閱紀錄API（創建訂單，未付款，不續訂，無付款/訂閱時間）👉打付款API👉webhook API收到扣款回傳結果👉更新此筆訂單（改為已付款、自動續訂、新增付款時間、訂閱時間）

2.第二次之後的授權，webhook API收到扣款回傳結果👉創建新的訂閱紀錄（前筆訂單不再續訂）

3.coach資料表少一個「是否已驗證」的欄位，順便補上

4.subscription訂單編號設為唯一值，避免webhook重複新增訂單。