### PR TITLE
feature：使用者上傳大頭貼

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const cookieParser = require("cookie-parser");
 const logger = require("morgan");
 const AppDataSource = require("./db/data-source");
 const generateError = require("./utils/generateError");
+const errorHandler = require("./middlewares/errorHandler");
 
 const indexRouter = require("./routes/index");
 const userRouter = require("./routes/user");
@@ -35,19 +36,14 @@ app.use("/api/v1/courses", courseRouter);
 app.use("/api/v1/admin", adminRouter);
 app.use("/api/v1/coaches", coachRouter);
 
-// catch 404 and forward to error handler
+// 上傳檔案的靜態路由
+app.use("/uploads", express.static("uploads"));
+
+// 錯誤處理中介軟體
 app.use(function (req, res, next) {
   next(generateError(404, "找不到該路由"));
 });
-
-// error handler
-app.use(function (err, req, res, next) {
-  const statusCode = err.statusCode || 500;
-  res.status(statusCode).json({
-    status: false,
-    message: err.message || "伺服器錯誤",
-  });
-});
+app.use(errorHandler);
 
 AppDataSource.initialize()
   .then(() => {

--- a/app.js
+++ b/app.js
@@ -36,9 +36,6 @@ app.use("/api/v1/courses", courseRouter);
 app.use("/api/v1/admin", adminRouter);
 app.use("/api/v1/coaches", coachRouter);
 
-// 上傳檔案的靜態路由
-app.use("/uploads", express.static("uploads"));
-
 // 錯誤處理中介軟體
 app.use(function (req, res, next) {
   next(generateError(404, "找不到該路由"));

--- a/config/cloudinary.js
+++ b/config/cloudinary.js
@@ -1,0 +1,5 @@
+module.exports = {
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+};

--- a/config/index.js
+++ b/config/index.js
@@ -10,6 +10,7 @@ const secret = require("./secret");
 const email = require("./email"); // 新增 email 設定
 const mux = require("./mux");
 const ecpay = require("./ecpay");
+const cloudinary = require("./cloudinary"); // 新增 cloudinary 設定
 
 // 整合所有設定檔案
 const config = {
@@ -19,6 +20,7 @@ const config = {
   email, // 添加 email 設定
   mux, //添加mux串流token
   ecpay, //綠界金流
+  cloudinary, // 添加 cloudinary 設定
 };
 
 class ConfigManager {

--- a/controllers/upload.js
+++ b/controllers/upload.js
@@ -8,10 +8,12 @@ const uploadAvatar = (req, res, next) => {
   if (req.file.fieldname !== "avatar") {
     return next(generateError(400, `欄位名稱錯誤: ${req.file.fieldname}，應為 avatar`));
   }
+
   // 建立完整url路徑
   const data = {
     userId: req.user.id,
     filename: req.file.filename, // 檔案名稱
+    publicId: req.file.filename, // Cloudinary 的 public_id = 檔案名稱
     url: req.file.path, // Cloudinary URL
     mimeType: req.file.mimetype, // 檔案類型
     size: req.file.size, // 檔案大小

--- a/controllers/upload.js
+++ b/controllers/upload.js
@@ -13,7 +13,8 @@ const uploadAvatar = (req, res, next) => {
   const data = {
     userId: req.user.id,
     filename: req.file.filename, // 檔案名稱
-    url: `${req.protocol}://${req.get("host")}/uploads/${req.file.filename}`,
+    publicId: req.file.public_id, // Cloudinary的public_id
+    url: req.file.path, // Cloudinary URL
     mimeType: req.file.mimetype, // 檔案類型
     size: req.file.size, // 檔案大小
   };

--- a/controllers/upload.js
+++ b/controllers/upload.js
@@ -4,7 +4,6 @@ const generateError = require("../utils/generateError");
 const uploadAvatar = (req, res, next) => {
   // 檢查是否有接收到檔案
   if (!req.file) return next(generateError(400, "未收到檔案"));
-
   // 檢查檔案欄位名稱
   if (req.file.fieldname !== "avatar") {
     return next(generateError(400, `欄位名稱錯誤: ${req.file.fieldname}，應為 avatar`));
@@ -13,7 +12,6 @@ const uploadAvatar = (req, res, next) => {
   const data = {
     userId: req.user.id,
     filename: req.file.filename, // 檔案名稱
-    publicId: req.file.public_id, // Cloudinary的public_id
     url: req.file.path, // Cloudinary URL
     mimeType: req.file.mimetype, // 檔案類型
     size: req.file.size, // 檔案大小

--- a/controllers/upload.js
+++ b/controllers/upload.js
@@ -1,0 +1,23 @@
+const generateError = require("../utils/generateError");
+
+// 上傳大頭貼功能模組
+const uploadAvatar = (req, res, next) => {
+  // 檢查是否有接收到檔案
+  if (!req.file) return next(generateError(400, "未收到檔案"));
+
+  // 檢查檔案欄位名稱
+  if (req.file.fieldname !== "avatar") {
+    return next(generateError(400, `欄位名稱錯誤: ${req.file.fieldname}，應為 avatar`));
+  }
+  // 建立完整url路徑
+  const data = {
+    userId: req.user.id,
+    filename: req.file.filename, // 檔案名稱
+    url: `${req.protocol}://${req.get("host")}/uploads/${req.file.filename}`,
+    mimeType: req.file.mimetype, // 檔案類型
+    size: req.file.size, // 檔案大小
+  };
+  res.status(200).json({ status: true, data });
+};
+
+module.exports = { uploadAvatar };

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1,5 +1,7 @@
 const bcrypt = require("bcryptjs");
 const { MoreThan, Like } = require("typeorm");
+const multer = require("multer");
+const path = require("path");
 //repo
 const AppDataSource = require("../db/data-source");
 const userRepo = AppDataSource.getRepository("User");

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1,7 +1,16 @@
 const bcrypt = require("bcryptjs");
+const cloudinary = require("cloudinary").v2;
+const logger = require("pino")({
+  transport: {
+    target: "pino-pretty",
+    options: {
+      colorize: true,
+      translateTime: "HH:MM:ss",
+      ignore: "pid,hostname",
+    },
+  },
+});
 const { MoreThan, Like } = require("typeorm");
-const multer = require("multer");
-const path = require("path");
 //repo
 const AppDataSource = require("../db/data-source");
 const userRepo = AppDataSource.getRepository("User");
@@ -112,9 +121,17 @@ async function patchProfile(req, res, next) {
       return next(generateError(400, "使用者 ID 格式不正確"));
 
     const user = await userRepo.findOneBy({ id: userId });
+    if (!user) return next(generateError(400, "使用者不存在"));
 
     // email及使用者ID無法修改,前端email欄位同步寫死，不能輸入
-    const { name, profile_image_url, oldPassword, newPassword, newPassword_check } = req.body;
+    const {
+      name,
+      profile_image_url,
+      profile_image_public_id,
+      oldPassword,
+      newPassword,
+      newPassword_check,
+    } = req.body;
 
     //目前暫無email驗證功能，禁止修改email
     if ("email" in req.body) {
@@ -125,18 +142,22 @@ async function patchProfile(req, res, next) {
     // 若值為字串，就回傳去掉前後空白的結果，空字串""就會回傳false
     // 若值為null或undefined,就不執行trim()，直接回傳undefined（false）
 
-    //判斷機制提取
+    // 檢查 name 是否有效（非空字串）
     const nameValidCheck = Boolean(name?.trim()); //name合格會回傳true
     let changeNameCheck = false;
     if (nameValidCheck) {
       changeNameCheck = name.trim() !== user.name; //name變更會回傳true
     }
 
+    // 檢查頭像圖片網址是否有效（非空字串）
     const profileValidCheck = Boolean(profile_image_url?.trim()); //url合格會回傳true
     let changeProfileCheck = false;
     if (profileValidCheck) {
       changeProfileCheck = profile_image_url.trim() !== user.profile_image_url; //url變更會回傳true
     }
+
+    //檢查 public_id是否有效（非空字串）
+    const publicIdValidCheck = Boolean(profile_image_public_id?.trim());
 
     // 若使用者想修改 name，檢查是否符合填寫規則
     if (nameValidCheck && changeNameCheck) {
@@ -152,6 +173,15 @@ async function patchProfile(req, res, next) {
     if (profileValidCheck && changeProfileCheck) {
       if (isNotValidUrl(profile_image_url)) {
         return next(generateError(400, "頭貼網址格式不正確"));
+      }
+      // 如果有新圖片URL，必須要有對應的 public_id
+      if (!publicIdValidCheck) {
+        return next(generateError(400, "更新頭像時必須提供有效的 public_id"));
+      }
+      // 檢查 public_id 格式（應該包含 user-avatars/ 前綴）
+      const trimmedPublicId = profile_image_public_id.trim();
+      if (!trimmedPublicId.startsWith("user-avatars/")) {
+        return next(generateError(400, "public_id 格式不正確"));
       }
     }
 
@@ -204,6 +234,16 @@ async function patchProfile(req, res, next) {
     ) {
       return next(generateError(400, "無資料需變更，請輸入欲修改的內容"));
     }
+    // 在更新資料庫前，先準備刪除舊圖片
+    let oldImagePublicId = null;
+    if (
+      profileValidCheck &&
+      changeProfileCheck &&
+      user.profile_image_url &&
+      user.profile_image_public_id
+    ) {
+      oldImagePublicId = user.profile_image_public_id || null;
+    }
 
     //修改變更的資料
     if (nameValidCheck && changeNameCheck) {
@@ -211,17 +251,33 @@ async function patchProfile(req, res, next) {
     }
     if (profileValidCheck && changeProfileCheck) {
       user.profile_image_url = profile_image_url.trim();
+      user.profile_image_public_id = profile_image_public_id.trim();
     }
     if (hasAllPasswordFields) {
       user.password = await bcrypt.hash(newPassword, 10);
     }
     await userRepo.save(user);
 
+    //資料庫更新成功後，在cloudinary刪除舊圖片
+    if (oldImagePublicId && oldImagePublicId !== profile_image_public_id?.trim()) {
+      try {
+        const deleteResult = await cloudinary.uploader.destroy(oldImagePublicId);
+        if (deleteResult.result === "ok") {
+          logger.info(`舊圖片刪除成功: ${deleteResult.result} (${oldImagePublicId})`);
+        } else {
+          logger.warn(`舊圖片刪除異常: ${deleteResult.result} (${oldImagePublicId})`);
+        }
+      } catch (error) {
+        logger.error(`舊圖片刪除失敗，請手動處理:${error}, public_id: ${oldImagePublicId}`);
+      }
+    }
+
     const userData = {
       id: user.id,
       name: user.name,
       email: user.email,
       profile_image_url: user.profile_image_url,
+      profile_image_public_id: user.profile_image_public_id,
       updated_at: user.updated_at,
     };
     res.status(200).json({ status: true, message: "成功更新資料", data: userData });

--- a/entities/User.js
+++ b/entities/User.js
@@ -56,6 +56,13 @@ module.exports = new EntitySchema({
       nullable: true,
     },
 
+    // 頭像圖片在cloudinary的public_id
+    profile_image_public_id: {
+      type: "varchar",
+      length: 2048,
+      nullable: true,
+    },
+
     // 資料建立時間（自動填入）
     created_at: {
       type: "timestamp",

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -1,5 +1,14 @@
 //logger套件
-const logger = require("pino")();
+const logger = require("pino")({
+  transport: {
+    target: "pino-pretty",
+    options: {
+      colorize: true,
+      translateTime: "HH:MM:ss",
+      ignore: "pid,hostname",
+    },
+  },
+});
 const secret = process.env.JWT_SECRET;
 const generateError = require("../utils/generateError");
 const { verifyJWT } = require("../utils/jwtUtils");

--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,0 +1,27 @@
+const errorHandler = (err, req, res, next) => {
+  let statusCode = err.statusCode || 500;
+  let message = err.message || "伺服器錯誤";
+
+  // 處理 multer 錯誤
+  if (err.message === "僅支援 JPG 或 PNG 檔案格式") {
+    statusCode = 400;
+  }
+  // multer官方提供的錯誤代碼
+  if (err.code === "LIMIT_UNEXPECTED_FILE") {
+    statusCode = 400;
+    message = "不允許的檔案欄位，只接受 'avatar' 欄位的單一檔案";
+  }
+
+  if (err.code === "LIMIT_FILE_SIZE") {
+    statusCode = 400;
+    message = "檔案太大，請上傳小於 2MB 的圖片";
+  }
+
+  // 預設錯誤回應
+  res.status(statusCode).json({
+    status: false,
+    message: message,
+  });
+};
+
+module.exports = errorHandler;

--- a/middlewares/upload.js
+++ b/middlewares/upload.js
@@ -1,0 +1,37 @@
+const multer = require("multer");
+const path = require("path");
+
+// 設定 multer 的儲存配置
+const storage = multer.diskStorage({
+  // 設定檔案儲存目錄
+  destination: function (req, file, cb) {
+    cb(null, "uploads/"); // 儲存到 uploads 資料夾
+  },
+  // 設定檔案命名規則
+  filename: function (req, file, cb) {
+    const ext = path.extname(file.originalname); // 取得原始檔案的副檔名
+    cb(null, `${Date.now()}${ext}`); // 以時間戳命名，避免檔名重複
+  },
+});
+
+// 檢查檔案類型
+const fileFilter = (req, file, cb) => {
+  const allowedTypes = ["image/jpeg", "image/jpg", "image/png"];
+  if (!allowedTypes.includes(file.mimetype)) {
+    // 若格式不符合，則不儲存檔案
+    return cb(new Error("僅支援 JPG 或 PNG 檔案格式"), false);
+  }
+  cb(null, true);
+};
+
+// 建立 upload 實例
+const upload = multer({
+  storage,
+  fileFilter,
+  limits: {
+    fileSize: 2 * 1024 * 1024, // 2MB
+    fileCount: 1, // 只允許上傳單一檔案
+  },
+});
+
+module.exports = upload;

--- a/middlewares/upload.js
+++ b/middlewares/upload.js
@@ -37,7 +37,7 @@ const upload = multer({
   fileFilter,
   limits: {
     fileSize: 2 * 1024 * 1024, // 2MB
-    fileCount: 1, // 只允許上傳單一檔案
+    files: 1, // 只允許上傳單一檔案
   },
 });
 

--- a/middlewares/upload.js
+++ b/middlewares/upload.js
@@ -3,25 +3,21 @@ const { CloudinaryStorage } = require("multer-storage-cloudinary");
 const cloudinary = require("cloudinary").v2;
 const config = require("../config/index");
 const { cloud_name, api_key, api_secret } = config.get("cloudinary");
+
 // 引入配置檔
 cloudinary.config({
   cloud_name: cloud_name,
   api_key: api_key,
   api_secret: api_secret,
 });
+
 // 設定cloudinary的儲存配置
 const storage = new CloudinaryStorage({
   cloudinary: cloudinary,
   params: {
     folder: "user-avatars", // Cloudinary 資料夾
-    allowed_formats: ["jpg", "png", "jpeg"], // 允許的格式
-    transformation: [
-      { width: 500, height: 500, crop: "limit" }, // 自動調整大小
-    ],
-    public_id: (req, file) => {
-      // 自定義檔案名稱
-      return `avatar_${req.user.id}_${Date.now()}`;
-    },
+    format: async (req, file) => "jpg", //儲存格式
+    public_id: (req, file) => `avatar_${req.user.id}_${Date.now()}`, // 自定義檔案名稱
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "http-errors": "~1.6.3",
         "jsonwebtoken": "^9.0.2",
         "morgan": "~1.9.1",
+        "multer": "^2.0.0",
         "node-cron": "^4.0.4",
         "nodemailer": "^7.0.2",
         "pg": "^8.14.1",
@@ -568,6 +569,12 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -728,6 +735,23 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.0.0",
@@ -966,6 +990,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -1010,6 +1049,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -2041,6 +2086,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2327,6 +2378,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -2334,6 +2394,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/morgan": {
@@ -2357,6 +2429,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.0.tgz",
+      "integrity": "sha512-bS8rPZurbAuHGAnApbM9d4h1wSoYqrOqkE+6a64KLMK9yWU7gJXBDDVklKQ3TPi9DRb85cRs6yXaC0+cjxRtRg==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2866,6 +2956,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/process-warning": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
@@ -2949,6 +3045,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -3178,6 +3289,23 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -3370,6 +3498,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typeorm": {
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.22.tgz",
@@ -3529,6 +3663,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@mux/mux-node": "^11.1.0",
         "bcryptjs": "^3.0.2",
+        "cloudinary": "^1.41.3",
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",
         "debug": "~2.6.9",
@@ -21,6 +22,7 @@
         "jsonwebtoken": "^9.0.2",
         "morgan": "~1.9.1",
         "multer": "^2.0.0",
+        "multer-storage-cloudinary": "^4.0.0",
         "node-cron": "^4.0.4",
         "nodemailer": "^7.0.2",
         "pg": "^8.14.1",
@@ -953,6 +955,30 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cloudinary": {
+      "version": "1.41.3",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-1.41.3.tgz",
+      "integrity": "sha512-4o84y+E7dbif3lMns+p3UW6w6hLHEifbX/7zBJvaih1E9QNMZITENQ14GPYJC4JmhygYXsuuBb9bRA3xWEoOfg==",
+      "license": "MIT",
+      "dependencies": {
+        "cloudinary-core": "^2.13.0",
+        "core-js": "^3.30.1",
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/cloudinary-core": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/cloudinary-core/-/cloudinary-core-2.13.1.tgz",
+      "integrity": "sha512-z53GPNWnvU0Zi+ns8CIVbZBfj7ps/++zDvwIyiFuq5p1MoK+KUCg0k5mBceDDHTnx1gHmHUd9aohS+gDxPNt6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "lodash": ">=4.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1050,6 +1076,17 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.42.0.tgz",
+      "integrity": "sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -2245,6 +2282,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -2446,6 +2489,15 @@
       },
       "engines": {
         "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/multer-storage-cloudinary": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multer-storage-cloudinary/-/multer-storage-cloudinary-4.0.0.tgz",
+      "integrity": "sha512-25lm9R6o5dWrHLqLvygNX+kBOxprzpmZdnVKH4+r68WcfCt8XV6xfQaMuAg+kUE5Xmr8mJNA4gE0AcBj9FJyWA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "cloudinary": "^1.21.0"
       }
     },
     "node_modules/natural-compare": {
@@ -3006,6 +3058,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "@eslint/js": "^9.27.0",
         "eslint": "^9.27.0",
         "globals": "^16.1.0",
-        "nodemon": "^3.1.9"
+        "nodemon": "^3.1.9",
+        "pino-pretty": "^13.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -997,6 +998,13 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1121,6 +1129,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -1236,6 +1254,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -1596,6 +1624,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1625,6 +1660,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -1953,6 +1995,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -2157,6 +2206,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-yaml": {
@@ -2701,6 +2760,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2953,6 +3022,31 @@
         "split2": "^4.0.0"
       }
     },
+    "node_modules/pino-pretty": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.0.0.tgz",
+      "integrity": "sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.2",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
@@ -3049,6 +3143,17 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3192,6 +3297,13 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -3913,6 +4025,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "http-errors": "~1.6.3",
     "jsonwebtoken": "^9.0.2",
     "morgan": "~1.9.1",
+    "multer": "^2.0.0",
     "node-cron": "^4.0.4",
     "nodemailer": "^7.0.2",
     "pg": "^8.14.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@eslint/js": "^9.27.0",
     "eslint": "^9.27.0",
     "globals": "^16.1.0",
-    "nodemon": "^3.1.9"
+    "nodemon": "^3.1.9",
+    "pino-pretty": "^13.0.0"
   },
   "main": "app.js",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@mux/mux-node": "^11.1.0",
     "bcryptjs": "^3.0.2",
+    "cloudinary": "^1.41.3",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "~2.6.9",
@@ -22,6 +23,7 @@
     "jsonwebtoken": "^9.0.2",
     "morgan": "~1.9.1",
     "multer": "^2.0.0",
+    "multer-storage-cloudinary": "^4.0.0",
     "node-cron": "^4.0.4",
     "nodemailer": "^7.0.2",
     "pg": "^8.14.1",

--- a/routes/user.js
+++ b/routes/user.js
@@ -3,9 +3,11 @@ const router = express.Router();
 const auth = require("../middlewares/auth");
 const isUser = require("../middlewares/isUser");
 const isSelf = require("../middlewares/isSelf");
+const upload = require("../middlewares/upload");
 const userController = require("../controllers/user");
 const ratingController = require("../controllers/rating");
 const paymentController = require("../controllers/payment");
+const { uploadAvatar } = require("../controllers/upload");
 
 //固定路由
 //固定路由順序要放在動態路由前，如:userId，否則會被/:userId的路由攔截
@@ -30,8 +32,10 @@ router.post("/create-payment", auth, isUser, paymentController.postCreatePayment
 router.post("/payment-confirm", paymentController.postPaymentConfirm);
 //取消定期扣款
 router.post("/cancel-payment", auth, isUser, paymentController.postCancelPayment);
-// 接收取消結果的通知（從前端導回）
+//TODO:接收取消結果的通知，待確認
 router.post("/cancel-confirm", paymentController.postCancelConfirm);
+//上傳大頭貼
+router.post("/upload-avatar", auth, isUser, upload.single("avatar"), uploadAvatar);
 
 //動態路由
 
@@ -49,7 +53,6 @@ router.get("/courses/:courseId/ratings", auth, isUser, ratingController.getRatin
 router.post("/:userId/ratings/:courseId", auth, isUser, isSelf, ratingController.postRating);
 //取得上課頁面詳細資訊
 router.get("/courses/:courseId/details", auth, isUser, userController.getCourseDetails);
-router.post("/:userId/ratings/:courseId", auth, isUser, isSelf, ratingController.postRating);
 //修改課程評價
 router.patch("/:userId/rating/:courseId", auth, isUser, isSelf, ratingController.patchRating);
 


### PR DESCRIPTION
1.新增使用者上傳大頭貼API
2.multer回傳的錯誤格式不適用generateError，所以放在errorHandler統一處理
3.用postman測試請在body選擇form-data，key名稱avatar，可上傳2mb以下的 jpeg/jpg/png格式檔案
4.修改個人資料，若有變更大頭貼，儲存編輯後，會刪除之前存在cloudinary的舊大頭貼
5.新增USER資料表欄位profile_image_public_id，有紀錄此id才能在雲端刪除對應圖片

使用者上傳的圖片會儲存在cloudinary雲端，搭配multer / multer-storage-cloudinary / cloudinary套件

參考網站
https://cloudinary.com/
https://github.com/expressjs/multer/blob/main/doc/README-zh-cn.md
https://www.npmjs.com/package/multer-storage-cloudinary/v/4.0.0?activeTab=readme

.env參數
CLOUDINARY_CLOUD_NAME=dgazasivw
CLOUDINARY_API_KEY=271153591736742
CLOUDINARY_API_SECRET=PzARTiTtKs_9rLqsOoPZoe1p8w0