### PR TITLE
fix：提取logger設置&調整dotenv重複載入

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -1,7 +1,3 @@
-// 僅在本地開發時才載入 .env 檔案
-if (process.env.NODE_ENV !== "production") {
-  require("dotenv").config();
-}
 module.exports = {
   host: process.env.DB_HOST,
   port: process.env.DB_PORT,
@@ -9,11 +5,5 @@ module.exports = {
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,
   synchronize: process.env.DB_SYNCHRONIZE === "true",
-  ssl:
-    process.env.DB_ENABLE_SSL === "true"
-      ? { rejectUnauthorized: false }
-      : undefined,
+  ssl: process.env.DB_ENABLE_SSL === "true" ? { rejectUnauthorized: false } : undefined,
 };
-
-//主要是用來連接資料庫的設定檔
-//把它包裝成物件 裡面跟我要去連接typeorm所需要的環境變數 做一次的整理

--- a/config/index.js
+++ b/config/index.js
@@ -1,8 +1,3 @@
-// 僅在本地開發時才載入 .env 檔案
-if (process.env.NODE_ENV !== "production") {
-  require("dotenv").config();
-}
-
 //config是針對環境變數的統一管理
 const db = require("./db");
 const web = require("./web");

--- a/config/logger.js
+++ b/config/logger.js
@@ -1,0 +1,28 @@
+const pino = require("pino");
+
+const isProduction = process.env.NODE_ENV === "production";
+
+let logger; // 先宣告變數
+
+//正式環境
+if (isProduction) {
+  logger = pino({
+    level: "info", // 設定日誌等級為 info
+    timestamp: pino.stdTimeFunctions.isoTime, // 使用 ISO 時間格式
+  });
+} else {
+  //開發環境
+  logger = pino({
+    level: "debug", // 設定日誌等級為 debug
+    transport: {
+      target: "pino-pretty",
+      options: {
+        colorize: true,
+        translateTime: "HH:MM:ss", // 時間格式
+        ignore: "pid,hostname",
+      },
+    },
+  });
+}
+
+module.exports = logger;

--- a/controllers/payment.js
+++ b/controllers/payment.js
@@ -1,5 +1,5 @@
 const dayjs = require("dayjs");
-const logger = require("pino")();
+const logger = require("../config/logger");
 const config = require("../config/index");
 const { merchantId, returnUrl, notifyUrl } = config.get("ecpay"); //引入綠界金流參數
 const { generateCMV } = require("../services/ecPayServices");

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1,15 +1,6 @@
 const bcrypt = require("bcryptjs");
 const cloudinary = require("cloudinary").v2;
-const logger = require("pino")({
-  transport: {
-    target: "pino-pretty",
-    options: {
-      colorize: true,
-      translateTime: "HH:MM:ss",
-      ignore: "pid,hostname",
-    },
-  },
-});
+const logger = require("../config/logger");
 const { MoreThan, Like } = require("typeorm");
 //repo
 const AppDataSource = require("../db/data-source");

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -1,14 +1,4 @@
-//logger套件
-const logger = require("pino")({
-  transport: {
-    target: "pino-pretty",
-    options: {
-      colorize: true,
-      translateTime: "HH:MM:ss",
-      ignore: "pid,hostname",
-    },
-  },
-});
+const logger = require("../config/logger");
 const secret = process.env.JWT_SECRET;
 const generateError = require("../utils/generateError");
 const { verifyJWT } = require("../utils/jwtUtils");


### PR DESCRIPTION
1. dotenv只需要在應用程式的入口點www.js載入過，環境變數就會全域可用，目前多處有重複載入，因此移除
2. logger設定提取到config/logger.js，pino-pretty只在測試環境使用，上render會報錯