### PR TITLE
fix: 取消定期定額扣款API發送請求格式修正

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -256,12 +256,16 @@ async function patchProfile(req, res, next) {
       try {
         const deleteResult = await cloudinary.uploader.destroy(oldImagePublicId);
         if (deleteResult.result === "ok") {
-          logger.info(`舊圖片刪除成功: ${deleteResult.result} (${oldImagePublicId})`);
+          logger.info("舊圖片刪除成功，舊圖片publicId%s", oldImagePublicId);
         } else {
-          logger.warn(`舊圖片刪除異常: ${deleteResult.result} (${oldImagePublicId})`);
+          logger.error(
+            "舊圖片刪除失敗，結果: %s，publicId: %s",
+            deleteResult.result,
+            oldImagePublicId
+          );
         }
       } catch (error) {
-        logger.error(`舊圖片刪除失敗，請手動處理:${error}, public_id: ${oldImagePublicId}`);
+        logger.error("舊圖片刪除失敗，錯誤:%s，public_id: %s", error, oldImagePublicId);
       }
     }
 
@@ -592,7 +596,6 @@ async function postSubscription(req, res, next) {
       newSubscription.is_paid = true; // 試用方案視為已付款
     }
 
-
     // 儲存訂閱紀錄
     const savedSubscription = await subscriptionRepo.save(newSubscription);
     if (!savedSubscription) {
@@ -643,8 +646,8 @@ async function postSubscription(req, res, next) {
           order_number: savedSubscription.order_number,
           price: savedSubscription.price,
           is_paid: savedSubscription.is_paid,
-          start_at: formatDate(savedSubscription.start_at),
-          end_at: formatDate(savedSubscription.end_at),
+          start_at: savedSubscription.start_at ? formatDate(savedSubscription.start_at) : null,
+          end_at: savedSubscription.end_at ? formatDate(savedSubscription.end_at) : null,
           created_at: formatDate(savedSubscription.created_at),
           updated_at: formatDate(savedSubscription.updated_at),
         },

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -98,7 +98,7 @@ module.exports = async (req, res, next) => {
     }
     next();
   } catch (error) {
-    logger.error(`[Auth] ${req.method} ${req.url}`, error);
+    logger.error("[Auth]error:%s", error);
     next(error);
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@mux/mux-node": "^11.1.0",
+        "axios": "^1.9.0",
         "bcryptjs": "^3.0.2",
         "cloudinary": "^1.41.3",
         "cookie-parser": "~1.4.4",
@@ -28,6 +29,7 @@
         "nodemailer": "^7.0.2",
         "pg": "^8.14.1",
         "pino": "^9.6.0",
+        "querystring": "^0.2.1",
         "reflect-metadata": "^0.2.2",
         "typeorm": "^0.3.22",
         "validator": "^13.15.0"
@@ -605,6 +607,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1750,6 +1763,26 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -3138,6 +3171,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -3184,6 +3223,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/quick-format-unescaped": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@mux/mux-node": "^11.1.0",
+    "axios": "^1.9.0",
     "bcryptjs": "^3.0.2",
     "cloudinary": "^1.41.3",
     "cookie-parser": "~1.4.4",
@@ -29,6 +30,7 @@
     "nodemailer": "^7.0.2",
     "pg": "^8.14.1",
     "pino": "^9.6.0",
+    "querystring": "^0.2.1",
     "reflect-metadata": "^0.2.2",
     "typeorm": "^0.3.22",
     "validator": "^13.15.0"

--- a/routes/user.js
+++ b/routes/user.js
@@ -32,8 +32,6 @@ router.post("/create-payment", auth, isUser, paymentController.postCreatePayment
 router.post("/payment-confirm", paymentController.postPaymentConfirm);
 //取消定期扣款
 router.post("/cancel-payment", auth, isUser, paymentController.postCancelPayment);
-//TODO:接收取消結果的通知，待確認
-router.post("/cancel-confirm", paymentController.postCancelConfirm);
 //上傳大頭貼
 router.post("/upload-avatar", auth, isUser, upload.single("avatar"), uploadAvatar);
 


### PR DESCRIPTION
1.取消定期定額扣款API發送請求格式修正（移除多餘取消扣款驗證API）
流程：前端點擊取消—觸發API-向綠界發送post取消請求-取得回傳結果-取消該訂單自動續訂
2.pino logger格式修正，zeabur控制台上才能正常讀取（1.物件在前，訊息在後 2.訊息內使用%s提取變數）
3.新增訂閱start_at end_at沒有值會顯示1970/01/01，補上=null防呆